### PR TITLE
[WIP] Set all template fields to active

### DIFF
--- a/message_ui.install
+++ b/message_ui.install
@@ -1,0 +1,23 @@
+<?php
+/**
+ * @file
+ * Contains Drupal\message_ui\message_ui.install.
+ */
+
+/**
+ * Implements hook_install().
+ */
+function message_ui_install() {
+  // Display all message fields on form and display.
+  foreach (\Drupal::entityTypeManager()->getStorage('message_template')->loadMultiple() as $template) {
+    /* @var $template Drupal\message\Entity\MessageTemplate */
+    $display = \Drupal::entityTypeManager()
+      ->getStorage('entity_view_display')
+      ->load('message_template' . '.' . $template->id() . '.' . 'default');
+
+    /* @var $display Drupal\Core\Entity\Display\EntityDisplayInterface */
+    foreach ($display->getComponents() as $component) {
+      debug($component);
+    }
+  }
+}

--- a/message_ui.module
+++ b/message_ui.module
@@ -44,7 +44,8 @@ function message_ui_entity_base_field_info_alter(&$fields, EntityTypeInterface $
             'placeholder' => '',
           ),
         ))
-        ->setDisplayConfigurable('form', TRUE);
+        ->setDisplayConfigurable('form', TRUE)
+        ->setRequired(TRUE);
     }
     if (!empty($fields['created'])) {
       $fields['created']->setDisplayOptions('view', array(


### PR DESCRIPTION
As outline in https://github.com/RoySegall/message_ui/issues/6, I tried for a few mins only this time to get all displays in the `hook_install`, but I imagine they are not set yet. So, maybe this needs to be in some kind of post install or elsewhere. Suggestions welcome...
