### PR TITLE
Display all form fields

### DIFF
--- a/config/install/message_ui.settings.yml
+++ b/config/install/message_ui.settings.yml
@@ -1,6 +1,15 @@
-update_tokens:
-  update_tokens: false
-  how_to_act: 'update_when_added'
-  number_items: 250
-show_preview: true
-anonymous: 'Anonymous'
+message_ui.settings:
+  type: config_object
+  label: 'Field settings'
+  mapping:
+    update_tokens:
+      type: message_ui.update_tokens
+    show_preview:
+      type: boolean
+      label: 'Show Preview'
+    anonymous:
+      type: string
+      label: 'Anonymous'
+    dispaly_all_fields:
+      type: boolean
+      label: 'Display all form fields when creating a message type'

--- a/config/install/message_ui.settings.yml
+++ b/config/install/message_ui.settings.yml
@@ -1,15 +1,14 @@
-message_ui.settings:
-  type: config_object
-  label: 'Field settings'
-  mapping:
-    update_tokens:
-      type: message_ui.update_tokens
-    show_preview:
-      type: boolean
-      label: 'Show Preview'
-    anonymous:
-      type: string
-      label: 'Anonymous'
-    dispaly_all_fields:
-      type: boolean
-      label: 'Display all form fields when creating a message type'
+type: config_object
+label: 'Field settings'
+mapping:
+  update_tokens:
+    type: message_ui.update_tokens
+  show_preview:
+    type: boolean
+    label: 'Show Preview'
+  anonymous:
+    type: string
+    label: 'Anonymous'
+  dispaly_all_fields:
+    type: boolean
+    label: 'Display all form fields when creating a message type'

--- a/src/MessagePermissions.php
+++ b/src/MessagePermissions.php
@@ -51,16 +51,16 @@ class MessagePermissions {
     $template_params = array('%template_name' => $template->label());
 
     return [
-      'view $template_id message' => [
+      'view ' . $template->id() . ' message' => [
         'title' => $this->t('%template_name: View a message instance', $template_params),
       ],
-      'edit $template_id message' => [
+      'edit ' . $template->id() . ' message' => [
         'title' => $this->t('%template_name: Edit a message instance', $template_params),
       ],
-      'create $template_id message' => [
+      'create ' . $template->id() . ' message' => [
         'title' => $this->t('%template_name: Create a new message instance', $template_params),
       ],
-      'delete $template_id message' => [
+      'delete ' . $template->id() . ' message' => [
         'title' => $this->t('%template_name: Delete a message instance', $template_params),
       ],
     ];


### PR DESCRIPTION
For issue: https://github.com/RoySegall/message_ui/issues/6

I changed the message settings to that suggested and fixed the dynamic permissions.

I noticed that when enabling the module, any subsequent custom `message_template` types created, then the fields / forms show, but for `message_example` templates for example, they are all hidden.

As documented in https://github.com/RoySegall/message_ui/pull/14 the install hook is likely too early to cycle through the displays as they don't exist yet.

It would be good to come up with a solid method before any work is done. I suggest an initial proposal:
1. Add a status message following enabling message_ui stating something like: "Message UI enabled, but some message fields may still be hidden. Bulk enable via the settings form here." Also update the README to state same.
2. Create either a Message UI settings form at `/admin/config/message/message_ui` or hook on the Message settings form at `/admin/config/message/message` and provide an "Display all Message template display fields" & "Display all Message Template form fields" buttons.
