### PR TITLE
Issue #2894234 by hctom, hctom: Object of class Drupal\message\Entity…

### DIFF
--- a/src/Form/MessageForm.php
+++ b/src/Form/MessageForm.php
@@ -231,7 +231,7 @@ class MessageForm extends ContentEntityForm {
     // Set up message link and status message contexts.
     $message_link = $message->link($this->t('View'));
     $context = [
-      '@type' => $message->getTemplate(),
+      '@type' => $message->getTemplate()->id(),
       '%title' => 'Message:' . $message->id(),
       'link' => $message_link,
     ];


### PR DESCRIPTION
…\MessageTemplate could not be converted to string in Drupal\syslog\Logger\SysLog->log()